### PR TITLE
Drawer API

### DIFF
--- a/example/src/DrawerExample.re
+++ b/example/src/DrawerExample.re
@@ -3,26 +3,18 @@ open Config;
 
 module Drawer =
   DrawerNavigation.Create({
+    open DrawerNavigation;
+
     type item = Config.item;
 
     let items = [Dashbord, Settings];
-    let drawerOptions =
-      DrawerNavigation.drawerOptions(~activeTintColor="#847", ());
 
-    let order = [Dashbord, Settings];
+    let drawerOptions = drawerOptions(~activeTintColor="#847", ());
 
     let getItem = tab =>
       switch (tab) {
-      | Dashbord => (
-          "Dashbord",
-          (() => <Items.Dashboard />),
-          DrawerNavigation.screenOptions(~title="Info", ()),
-        )
-      | Settings => (
-          "Settings",
-          (() => <Items.Settings />),
-          DrawerNavigation.screenOptions(~title="Settings", ()),
-        )
+      | Dashbord => (<Items.Dashboard />, screenOptions(~title="Info___"))
+      | Settings => (<Items.Settings />, screenOptions(~title="Settings"))
       };
   });
 

--- a/example/src/TabExample.re
+++ b/example/src/TabExample.re
@@ -15,17 +15,17 @@ module Tabs =
       switch (tab) {
       | Info => (
           "Info",
-          ((navigation) => <Tabs.Info navigation/>),
+          (navigation => <Tabs.Info navigation />),
           TabNavigator.screenOptions(~title="Info", ()),
         )
       | Profile => (
           "Profile",
-          ((navigation) => <Tabs.Profile navigation/>),
+          (navigation => <Tabs.Profile navigation />),
           TabNavigator.screenOptions(~title="Profile", ()),
         )
       | Settings => (
           "Settings",
-          ((navigation) => <Tabs.Settings navigation/>),
+          (navigation => <Tabs.Settings navigation />),
           TabNavigator.screenOptions(~title="Settings", ()),
         )
       };
@@ -35,6 +35,6 @@ module Tabs =
 let render = Tabs.render;
 
 let make = (~navigation, _children) => {
-  ...(ReasonReact.statelessComponent("TabExample")),
-  render: _ => Tabs.render
-}
+  ...ReasonReact.statelessComponent("TabExample"),
+  render: _ => Tabs.render,
+};


### PR DESCRIPTION
I removed the additional string in Drawer configuration. I use the screenOptions to get the name of drawer item.


cc @grabbou I think we don't need to generate the hash for route name because who will want to create two items with the same title? :D It doesn't have any sense :D