### PR TITLE
Add some header style options to StackNavigator.screenOptions

### DIFF
--- a/example/src/StackExample.re
+++ b/example/src/StackExample.re
@@ -37,17 +37,11 @@ module Stack =
       switch (route) {
       | Home => (
           <Screen navigation />,
-          screenOptions(
-            ~title="Home",
-            ~headerStyle,
-            ~headerTitleStyle,
-            ~headerTintColor,
-            (),
-          ),
+          screenOptions(~title="Home", ~headerStyle, ~headerTitleStyle, ()),
         )
       | UserDetails(userId) => (
           <Screen navigation text={"Browsing profile of: " ++ userId} />,
-          screenOptions(~title="Hello " ++ userId, ()),
+          screenOptions(~title="Hello " ++ userId, ~headerTintColor, ()),
         )
       };
   });

--- a/example/src/StackExample.re
+++ b/example/src/StackExample.re
@@ -9,6 +9,7 @@ open Config;
 module Stack =
   StackNavigator.Create({
     open StackNavigator;
+    open BsReactNative;
 
     /**
       * StackNavigator requires `route` type to be defined.
@@ -28,9 +29,22 @@ module Stack =
       *
       * This is to allow optional fields to be provided.
       */
+    let headerStyle =
+      Style.style([Style.backgroundColor(String("#3498db"))]);
+    let headerTitleStyle = Style.style([Style.color(String("#f1c40f"))]);
+    let headerTintColor = Style.String("red");
     let getScreen = (route, navigation) =>
       switch (route) {
-      | Home => (<Screen navigation />, screenOptions(~title="Home", ()))
+      | Home => (
+          <Screen navigation />,
+          screenOptions(
+            ~title="Home",
+            ~headerStyle,
+            ~headerTitleStyle,
+            ~headerTintColor,
+            (),
+          ),
+        )
       | UserDetails(userId) => (
           <Screen navigation text={"Browsing profile of: " ++ userId} />,
           screenOptions(~title="Hello " ++ userId, ()),

--- a/src/StackNavigator.re
+++ b/src/StackNavigator.re
@@ -7,6 +7,12 @@ type navigation('a) = {
 type screenOptions = {
   [@bs.optional]
   title: string,
+  [@bs.optional]
+  headerStyle: BsReactNative.Style.t,
+  [@bs.optional]
+  headerTitleStyle: BsReactNative.Style.t,
+  [@bs.optional]
+  headerTintColor: BsReactNative.Style.color,
 };
 
 module type StackConfig = {


### PR DESCRIPTION
Hello, I'm very new to `bs-react-navigation` / `ReasonML` and trying to build something with it.

I found I need to add some custom style on the StackNavigator header while I using it, so I make a PR on this.

Any advice is welcome, thank you.